### PR TITLE
Add info about "python-dbus" to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ These are:
 - python-pyside
 - gir1.2-unity
 - gir1.2-notify
+- python-dbus
 - maybe something more, let me know
 
 ## How to run it?


### PR DESCRIPTION
@teobaluta noticed that "python-dbus" is needed on Ubuntu 16.04 ( https://github.com/mivoligo/Zeegaree/issues/8 )